### PR TITLE
Do not throw panic on panic in Handler

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -110,7 +110,7 @@ func (c *Connection) Serve() {
 
 			c.Server.Log.WithFields(cue.Fields{
 				"person_id": c.Conn.RemoteAddr().String(),
-			}).Panic(err, "unhandled server connection error")
+			}).Error(fmt.Errorf("%v", err), "unhandled server connection error")
 		}
 		c.Close()
 	}()


### PR DESCRIPTION
[Trello](https://trello.com/c/ErDx5oQ3)

`cue.Panic` doesn't flush all events before panic.