### PR TITLE
Fix Server.Stop() to wait for handlers to finish

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -46,7 +46,6 @@ func (listener *Listener) Accept() (conn net.Conn, err error) {
 }
 
 func (listener *Listener) Run(callback func(*Listener) error) error {
-	listener.wg.Add(1)
 	defer listener.wg.Done()
 	return callback(listener)
 }

--- a/listener.go
+++ b/listener.go
@@ -31,6 +31,7 @@ func NewListener(port int) (listener *Listener, err error) {
 	return listener, nil
 }
 
+// revive:disable:var-naming
 func NewTlsListener(port int, config *tls.Config) (listener *Listener, err error) {
 	listener, err = NewListener(port)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -128,16 +128,16 @@ func (server *Server) Stop() {
 		server.listener.Wait()
 	}
 
-	server.waitForRequests()
+	server.waitForConnectionsToClose()
 }
 
 // StopDeadline is the hard deadline, after which Server.Stop() does no longer
-// wait for handlers to finish and returns.
+// wait for connections to close and returns.
 var StopDeadline = time.Minute
 
-// waitForRequests waits until all the handlers from listener and tlsListener
-// are done and close their connections.
-func (server *Server) waitForRequests() {
+// waitForConnectionsToClose waits until all the handlers from listener and
+// tlsListener are done and closed their connections.
+func (server *Server) waitForConnectionsToClose() {
 	deadline := time.NewTimer(StopDeadline)
 	for {
 		if server.numConns.Count() == 0 {
@@ -148,7 +148,6 @@ func (server *Server) waitForRequests() {
 		select {
 		case <-deadline.C:
 			server.Log.Warnf("not all requests finished after %v", StopDeadline)
-			deadline.Stop()
 			break
 		case <-time.After(time.Millisecond):
 		}

--- a/server.go
+++ b/server.go
@@ -101,9 +101,9 @@ func (server *Server) Run() error {
 		return err
 	}
 
-	go server.Serve()
+	server.Serve()
 	if server.HasTLS() {
-		go server.ServeTLS()
+		server.ServeTLS()
 	}
 
 	return nil
@@ -156,11 +156,17 @@ func (server *Server) waitForRequests() {
 }
 
 func (server *Server) Serve() {
-	server.Log.Panic(server.listener.Run(server.acceptLoop), "could not run the listener")
+	server.listener.wg.Add(1)
+	go func() {
+		server.Log.Panic(server.listener.Run(server.acceptLoop), "could not run the listener")
+	}()
 }
 
 func (server *Server) ServeTLS() {
-	server.Log.Panic(server.tlsListener.Run(server.acceptLoop), "could not run the TLS listener")
+	server.tlsListener.wg.Add(1)
+	go func() {
+		server.Log.Panic(server.tlsListener.Run(server.acceptLoop), "could not run the TLS listener")
+	}()
 }
 
 func (server *Server) acceptLoop(listener *Listener) error {

--- a/server_test.go
+++ b/server_test.go
@@ -13,11 +13,11 @@ func TestShutdownSegfault(t *testing.T) {
 	// test for multiple times so that the segfault happens
 	// with a high probability
 	for i := 0; i < 100; i++ {
-		testShutdownSegfault(t)
+		testStop(t)
 	}
 }
 
-func testShutdownSegfault(t *testing.T) {
+func testStop(t *testing.T) {
 	s, err := NewServer(testPort)
 	if err != nil {
 		t.Error(err)
@@ -65,7 +65,7 @@ type testHandler struct {
 	resource *int
 }
 
-func (h *testHandler) Handle(c *Connection) {
+func (h *testHandler) Handle(_ *Connection) {
 	// use the resource that gets removed after Stop()
 	_ = *h.resource
 }

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+// some random high port for testing
+const testPort = 60863
+
+func TestShutdownSegfault(t *testing.T) {
+	// test for multiple times so that the segfault happens
+	// with a high probability
+	for i := 0; i < 100; i++ {
+		testShutdownSegfault(t)
+	}
+}
+
+func testShutdownSegfault(t *testing.T) {
+	s, err := NewServer(testPort)
+	if err != nil {
+		t.Error(err)
+	}
+
+	val := 2
+	handler := &testHandler{&val}
+	s.Handler = handler
+
+	dials := make(chan bool)
+	go makeRequests(t, dials)
+
+	err = s.Run()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// wait until the first request was started
+	<-dials
+
+	// if Stop() doesn't wait correctly, the resource that is
+	// removed after it will trigger a segfault in Handle()
+	s.Stop()
+	handler.resource = nil
+}
+
+func makeRequests(t *testing.T, dials chan<- bool) {
+	for i := 0; i < 100; i++ {
+		c, err := net.Dial("tcp", fmt.Sprint("localhost:", testPort))
+		if err != nil {
+			break
+		}
+		select {
+		case dials <- true:
+		default:
+		}
+		err = c.Close()
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+type testHandler struct {
+	resource *int
+}
+
+func (h *testHandler) Handle(c *Connection) {
+	// use the resource that gets removed after Stop()
+	_ = *h.resource
+}

--- a/server_test.go
+++ b/server_test.go
@@ -69,3 +69,16 @@ func (h *testHandler) Handle(c *Connection) {
 	// use the resource that gets removed after Stop()
 	_ = *h.resource
 }
+
+func TestRunStopRace(t *testing.T) {
+	s, err := NewServer(testPort)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = s.Run()
+	if err != nil {
+		t.Error(err)
+	}
+	s.Stop()
+}


### PR DESCRIPTION
fix Server.Stop() function so that it waits for handlers to be finished

Original bug: a resource that was removed after Stop() returned caused a
segfault in the handler function that still used that resource. To fix this
Stop() polls `Server.numConns` and only returns if the value is zero or a
stopping deadline of 1 minute was reached.

- fixes a data race with the listener WaitGroups
- fixes a data race with listener stopped state