### PR TITLE
[3821] Create client service for Server

### DIFF
--- a/client_service.go
+++ b/client_service.go
@@ -9,8 +9,6 @@ import (
 )
 
 type ServerConfig struct {
-	DefaultPort int
-
 	Port int
 	TLS  struct {
 		Port int
@@ -52,7 +50,7 @@ func (s *ClientService) configureFlags(cmd *cobra.Command) {
 
 	flags.IntVar(
 		&s.config.Port,
-		"server-port", s.config.DefaultPort,
+		"server-port", s.config.Port,
 		"HTTP server port",
 	)
 

--- a/client_service.go
+++ b/client_service.go
@@ -21,7 +21,7 @@ type ServerConfig struct {
 	MaxConns                   int64
 	MaxConcurrentTLSHandshakes int64
 
-	Handler Handler
+	CreateHandler func() Handler
 }
 
 type ClientServiceParams struct {
@@ -92,7 +92,7 @@ func (s *ClientService) Init() error {
 
 	s.Server.MaxConns = s.config.MaxConns
 	s.Server.MaxConcurrentTLSHandshakes = s.config.MaxConcurrentTLSHandshakes
-	s.Server.Handler = s.config.Handler
+	s.Server.Handler = s.config.CreateHandler()
 
 	return s.Server.Run()
 }

--- a/client_service.go
+++ b/client_service.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"os"
+
+	"github.com/remerge/go-service"
+	"github.com/remerge/go-service/registry"
+	"github.com/spf13/cobra"
+)
+
+type ServerConfig struct {
+	DefaultPort int
+
+	Port int
+	TLS  struct {
+		Port int
+		Cert string
+		Key  string
+	}
+
+	MaxConns                   int64
+	MaxConcurrentTLSHandshakes int64
+
+	Handler Handler
+}
+
+type ClientServiceParams struct {
+	registry.Params
+
+	*ServerConfig `registry:"lazy"`
+}
+
+type ClientService struct {
+	Server *Server
+
+	config *ServerConfig
+}
+
+func RegisterService(r service.Registry) {
+	r.Register(func(cmd *cobra.Command, p *ClientServiceParams) (*ClientService, error) {
+		s := &ClientService{
+			config: p.ServerConfig,
+		}
+		s.configureFlags(cmd)
+
+		return s, nil
+	})
+}
+
+func (s *ClientService) configureFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	flags.IntVar(
+		&s.config.Port,
+		"server-port", s.config.DefaultPort,
+		"HTTP server port",
+	)
+
+	flags.IntVar(
+		&s.config.TLS.Port,
+		"server-tls-port", 0,
+		"HTTPS server port",
+	)
+
+	flags.StringVar(
+		&s.config.TLS.Cert,
+		"server-tls-cert", "",
+		"HTTPS server certificate",
+	)
+
+	flags.StringVar(
+		&s.config.TLS.Key,
+		"server-tls-key", "",
+		"HTTPS server certificate key",
+	)
+
+}
+
+func (s *ClientService) Init() error {
+	var err error
+
+	s.Server, err = NewServerWithTLS(
+		s.config.Port,
+		s.config.TLS.Port,
+		s.config.TLS.Key,
+		s.config.TLS.Cert,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	s.Server.MaxConns = s.config.MaxConns
+	s.Server.MaxConcurrentTLSHandshakes = s.config.MaxConcurrentTLSHandshakes
+	s.Server.Handler = s.config.Handler
+
+	return s.Server.Run()
+}
+
+func (s *ClientService) Shutdown(os.Signal) {
+	if s.Server != nil {
+		s.Server.Stop()
+	}
+}

--- a/client_service.go
+++ b/client_service.go
@@ -27,13 +27,13 @@ type ServerConfig struct {
 type ClientServiceParams struct {
 	registry.Params
 
-	*ServerConfig `registry:"lazy"`
+	ServerConfig `registry:"lazy"`
 }
 
 type ClientService struct {
 	Server *Server
 
-	config *ServerConfig
+	config ServerConfig
 }
 
 func RegisterService(r service.Registry) {

--- a/client_service.go
+++ b/client_service.go
@@ -19,7 +19,7 @@ type ServerConfig struct {
 	MaxConns                   int64
 	MaxConcurrentTLSHandshakes int64
 
-	CreateHandler func() Handler
+	Handler func() Handler
 }
 
 type ClientServiceParams struct {
@@ -90,7 +90,7 @@ func (s *ClientService) Init() error {
 
 	s.Server.MaxConns = s.config.MaxConns
 	s.Server.MaxConcurrentTLSHandshakes = s.config.MaxConcurrentTLSHandshakes
-	s.Server.Handler = s.config.CreateHandler()
+	s.Server.Handler = s.config.Handler()
 
 	return s.Server.Run()
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,11 @@
 module github.com/remerge/go-server
 
 require (
-	github.com/rcrowley/go-metrics v0.0.0-20161128210544-1f30fe9094a5
-	github.com/remerge/cue v0.0.0-20170828190423-69c896c02169
+	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
+	github.com/remerge/cue v0.0.0-20180404154012-5ce627d813ef
+	github.com/remerge/go-service v0.0.0-20190815130235-3f9cdf8ede6a
+	github.com/spf13/cobra v0.0.3
+	github.com/spf13/pflag v1.0.3 // indirect
+	golang.org/x/net v0.0.0-20190923162816-aa69164e4478 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
This PR introduces a DI service which can be used by other services.

`Handler` is not set directly because at the time of service registration the dependencies are not resolved.

https://trello.com/c/EBFhPr2k/3821-fix-panic-on-debug-forwarder