### PR TITLE
close all connections when closing server

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -170,8 +170,8 @@ func (c *Connection) closeInternal() {
 // that is potentially already in use in a different go routine
 func (c *Connection) Close() {
 	c.closeMutex.Lock()
-	defer c.closeMutex.Unlock()
 	c.closeInternal()
+	c.closeMutex.Unlock()
 	// put connection back into pool
 	putConnection(c)
 }

--- a/connection.go
+++ b/connection.go
@@ -57,8 +57,8 @@ func newConnection() *Connection {
 func putConnection(c *Connection) {
 	c.Server.numConns.Dec(1)
 	c.Server.connectionsMutex.Lock()
-	defer c.Server.connectionsMutex.Unlock()
 	delete(c.Server.connections, c)
+	c.Server.connectionsMutex.Unlock()
 
 	c.Conn = nil
 	c.Server = nil

--- a/server.go
+++ b/server.go
@@ -46,10 +46,11 @@ type Server struct {
 
 func NewServer(port int) (server *Server, err error) {
 	server = &Server{
-		Id:         fmt.Sprintf("server:%d", port),
-		Port:       port,
-		BufferSize: 32768,
-		Timeout:    3 * time.Second,
+		Id:          fmt.Sprintf("server:%d", port),
+		Port:        port,
+		BufferSize:  32768,
+		Timeout:     3 * time.Second,
+		connections: make(map[*Connection]struct{}),
 	}
 
 	server.Log = cue.NewLogger(server.Id)

--- a/server.go
+++ b/server.go
@@ -3,8 +3,8 @@ package server
 import (
 	"crypto/tls"
 	"fmt"
-	"sync"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/rcrowley/go-metrics"


### PR DESCRIPTION
The main problem here - we do not close connections. Some connections are waiting for new data (for quite some time, more than a minute), so closing the connection look on the bidder side will not work. 

We need to close all server connections, not only listeners (that just prohibit to accept new connections). Then th