### PR TITLE
Partial elimination the risk of exhausted socket descriptors while running a stress test

### DIFF
--- a/.github/workflows/go-lib.yml
+++ b/.github/workflows/go-lib.yml
@@ -10,5 +10,3 @@ on:
 jobs:
   go-checks:
     uses: remerge/workflows/.github/workflows/go-checks.yml@main
-    secrets:
-      ssh_key: ${{ secrets.DEPLOY_USER_SSH_KEY }}

--- a/.github/workflows/go-lib.yml
+++ b/.github/workflows/go-lib.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   go-checks:
     uses: remerge/workflows/.github/workflows/go-checks.yml@main
-    secrets:
+    with:
       goprivate: ''

--- a/.github/workflows/go-lib.yml
+++ b/.github/workflows/go-lib.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   go-checks:
     uses: remerge/workflows/.github/workflows/go-checks.yml@main
+    secrets:
+      goprivate: ''

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/remerge/go-server
 
-go 1.18
+go 1.20
 
 require (
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,12 @@ module github.com/remerge/go-server
 go 1.18
 
 require (
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20180503174638-e2704e165165
 	github.com/remerge/cue v0.0.0-20180404154012-5ce627d813ef
 	github.com/spf13/cobra v0.0.3
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/remerge/go-server
 
-go 1.15
+go 1.18
 
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/server.go
+++ b/server.go
@@ -1,3 +1,4 @@
+// Package server provides a foundation for creating remerge-style servers
 package server
 
 import (

--- a/server_test.go
+++ b/server_test.go
@@ -27,8 +27,8 @@ func testStop(t *testing.T) {
 	handler := &testHandler{&val}
 	s.Handler = handler
 
-	dials := make(chan bool)
-	go makeRequests(t, dials)
+	dials, done := make(chan struct{}), make(chan struct{})
+	go makeRequests(t, dials, done)
 
 	err = s.Run()
 	if err != nil {
@@ -42,16 +42,25 @@ func testStop(t *testing.T) {
 	// removed after it will trigger a segfault in Handle()
 	s.Stop()
 	handler.resource = nil
+
+	// Since this function is called within a loop, the spawned `makeRequests` goroutine
+	// could continue to work (until the inner loops ends). Since each goroutine allocates
+	// new N file descriptors while the previous one are not deallocated yet, this leads to
+	// an overall test timeout (the underlying `net` waits for the descriptors available).
+	// To avoid this, we want to ensure that all `makeRequests` are called in sequence;
+	// this also makes sense when the test is run under the race checker, when multiple
+	// execution flows are triggered at time.
+	<-done
 }
 
-func makeRequests(t *testing.T, dials chan<- bool) {
+func makeRequests(t *testing.T, dials chan<- struct{}, done chan<- struct{}) {
 	for i := 0; i < 100; i++ {
 		c, err := net.Dial("tcp", fmt.Sprint("localhost:", testPort))
 		if err != nil {
 			break
 		}
 		select {
-		case dials <- true:
+		case dials <- struct{}{}:
 		default:
 		}
 		err = c.Close()
@@ -59,6 +68,7 @@ func makeRequests(t *testing.T, dials chan<- bool) {
 			t.Error(err)
 		}
 	}
+	done <- struct{}{}
 }
 
 type testHandler struct {


### PR DESCRIPTION
This PR addresses a flaky CI issue faced [here](https://github.com/remerge/go-server/pull/20#issuecomment-1577006607)

**NB** the original issue still could be reproduced (at least locally), since the fd-resources are freed up with some delay. So the last resort for the case (unless the test re-worked) would be adding some sleep 🙈 while running on CI (to give a host system moment to de-allocate fd-resources)